### PR TITLE
Mapreduce-based calculation of layoutmetrics

### DIFF
--- a/src/layoutstats.js
+++ b/src/layoutstats.js
@@ -197,6 +197,26 @@ LayoutStats.addMetric({
 
 LayoutStats.addMetric({
 	group: "text",
+	name: "RelativeLineHeight",
+	value: function (node){
+		var textStyle = getComputedStyle(node.parentNode);
+		var lineHeight = parseInt(textStyle.lineHeight,10);
+		var fontSize= parseInt(textStyle.fontSize,10);
+		if (!(isNaN(lineHeight) || isNaN(fontSize))){
+			var relativeLineHeight = (lineHeight / fontSize).toFixed(2) + 'px';
+			return {key: relativeLineHeight, value: node.textContent.length};
+		}
+		else {
+			// use browser default if we cannot determine line height
+			// see https://developer.mozilla.org/de/docs/Web/CSS/line-height#Values
+			return {key: 1.2, value: node.textContent.length}
+		}
+	},
+	reduce: ['average']
+});
+
+LayoutStats.addMetric({
+	group: "text",
 	name: "FontStyle",
 	value: function (node){
 		var css = getComputedStyle(node.parentNode); //$textParent.css(['fontFamily','fontSize','fontWeight','fontVariant','fontStyle','color']);

--- a/src/layoutstats.js
+++ b/src/layoutstats.js
@@ -80,6 +80,12 @@ function incrementAcc (acc, item){
 	return acc;
 }
 
+function sortKeysByValue (obj){
+	return Object.keys(obj).sort(function(keyA, keyB){
+		return obj[keyB] - obj[keyA];
+	});
+}
+
 var reducers = {
 	'sum': {
 		fn: function (acc, item){
@@ -110,24 +116,30 @@ var reducers = {
 		metricPrefix: 'Unique',
 		metricSuffix: 'Count'
 	},
+	'uniquekeylist': {
+		fn: function (acc, item, itemIndex, array){
+			acc = incrementAcc(acc, item);
+
+			if (itemIndex === array.length -1){
+				return sortKeysByValue(acc);
+			}
+			return acc;
+		},
+		initialValue: {},
+		metricSuffix: 'List',
+	},
 	'top': {
 		fn: function (acc, item, itemIndex, array){
 			acc = incrementAcc(acc, item);
 			//return the total count if we arrived at the last element
 			if (itemIndex === array.length -1){
-				var descendingOrder = Object.keys(acc).sort(function(keyA, keyB){
-					return acc[keyB] -acc[keyA]
-				});
-				return descendingOrder[0];
+				return sortKeysByValue(acc)[0];
 			}
 			return acc;
 		},
 		initialValue: {},
 		metricPrefix: "Top"
 	}
-
-
-
 }
 
 var rgbToHex = function (rgbStr){
@@ -163,7 +175,7 @@ LayoutStats.addMetric({
 		var firstFont = fontFamilies.split(",")[0];
 		return {key: firstFont.toLowerCase(), value: node.textContent.length};
 	},
-	reduce: ['unique','uniquecount','top']
+	reduce: ['unique','uniquecount','uniquekeylist', 'top']
 });
 
 LayoutStats.addMetric({

--- a/src/layoutstats.js
+++ b/src/layoutstats.js
@@ -1,14 +1,16 @@
 ;( function( window, document, undefined ) {
-	window.layoutstats = function (rootNode, options){
-		var selectedNodes;
-		if (rootNode instanceof Element){
-			selectedNodes = [rootNode]
-		}
-		else {
-			selectedNodes = document.querySelectorAll(rootNode);
-		}
 
-		var _getVisibleTextNodes = function (element){
+	function _isVisible(elem){
+		return  !(elem.offsetWidth === 0 && elem.offsetHeight === 0);
+	}
+
+
+	function LayoutStats (){
+		var self = this;
+
+		this.metrics = this.constructor.metrics;
+
+		this._getVisibleTextNodes = function (element){
 			var walker = document.createTreeWalker(
 				element,
 				NodeFilter.SHOW_TEXT,
@@ -27,153 +29,209 @@
 				}
 			}
 			return textNodes;
-		};
-
-		var _updateCount = function (obj, key, count){
-			if (!obj[key]){
-				obj[key] = count;
-			}
-			else {
-				obj[key] += count;
-			}
 		}
 
-		function _toText(nodes){
-			var textContent = [];
-			nodes.forEach(function(node){
-				textContent.push(node.textContent);
-			});
-			return textContent.join('');
+
+		this.measure = function (node, options){
+			var nodes = self._getVisibleTextNodes(node);
+			 var measurements = {};
+			 self.metrics.forEach(function (metric) {
+				 var key = metric.name;
+				 var value = nodes.map(metric.value);
+				 if (metric.reduce) {
+
+					 var metricReducers = (Array.isArray(metric.reduce) ? metric.reduce : [metric.reduce]);
+
+					 metricReducers.forEach(function (metricReducer) {
+						 var reducer = (reducers[metricReducer] ? reducers[metricReducer] : metricReducer);
+						 //initialValue is an object property -> passed by reference, we need to clone it for a "clean" copy
+						 var clonedInitial = JSON.parse(JSON.stringify(reducer.initialValue));
+						 var reducedValue = value.reduce(reducer.fn, clonedInitial);
+						 var reduceKey = metric.group + (reducer.metricPrefix || '') + key + (reducer.metricSuffix || '');
+						 measurements[reduceKey] = reducedValue;
+					 });
+				 }
+				 //no reduce func
+				 else {
+					 measurements[ metric.group + key] = value;
+				 }
+
+			})
+			return measurements;
 		}
-
-		function _isVisible(elem){
-			return  !(elem.offsetWidth === 0 && elem.offsetHeight === 0);
-		}
-
-		var _count = function (obj){
-			return Object.keys(obj).length;
-		}
-
-		//taken from http://youmightnotneedjquery.com/
-		var _extend = function(out) {
-			out = out || {};
-
-			for (var i = 1; i < arguments.length; i++) {
-				if (!arguments[i])
-					continue;
-				for (var key in arguments[i]) {
-					if (arguments[i].hasOwnProperty(key))
-						out[key] = arguments[i][key];
-				}
-			}
-			return out;
-		};
-
-		var getUniqueFontStyles = function(element){
-			var unique = {
-				fontStyles: {},
-				fontColors: {},
-				fontSizes: {},
-				fonts: {}
-			},
-			visibleTextNodes = _getVisibleTextNodes(element);
-
-			var fontStyles = visibleTextNodes.forEach(function(node){
-				var textParent = node.parentNode;
-				var css = getComputedStyle(textParent); //$textParent.css(['fontFamily','fontSize','fontWeight','fontVariant','fontStyle','color']);
-				var styleParams = _extend({},css);
-				styleParams.color = rgbToHex(styleParams.color);
-				styleParams.fontSize = Math.round(parseInt(styleParams.fontSize, 10)) + 'px';
-				var miscProperties = '';
-				miscProperties += (styleParams.fontWeight === "bold" || parseInt(styleParams.fontWeight, 10) > 699 ? "bold": ""); //bold font?
-				miscProperties += (styleParams.fontStyle !== "normal" ? " " +styleParams.fontStyle: ""); //italics font?
-				miscProperties += (styleParams.fontVariant !== "normal" ? " " + styleParams.fontVariant: ""); //small caps?
-
-				var nodeStyle = [
-					styleParams.fontFamily.split(",")[0],
-					styleParams.fontSize,
-					styleParams.color,
-				];
-
-				if (miscProperties.length > 0){
-					nodeStyle.push(miscProperties);
-				}
-				nodeStyle = nodeStyle.join(" ");
-
-				var numChars = getVisibleCharCount(textParent);
-				if (numChars > 0){
-					_updateCount(unique.fontStyles, nodeStyle, numChars);
-					_updateCount(unique.fonts, styleParams.fontFamily.split(",")[0], numChars);
-					_updateCount(unique.fontColors, styleParams.color, numChars);
-					_updateCount(unique.fontSizes, styleParams.fontSize, numChars);
-				}
-
-			});
-			return unique;
-		}
-
-		var getVisibleCharCount = function(element){
-			var visibleTextNodes = _getVisibleTextNodes(element);
-			return _toText(visibleTextNodes).length;
-		};
-
-		var getMaxProperty = function (obj){
-			var arrayObj =  Object.keys(obj).map(function(key){
-				return {key: key, val: obj[key]}
-			});
-
-			arrayObj.sort(function(a, b){
-				return a.val - b.val;
-			}).reverse();
-
-			var maxProp = arrayObj[0];
-
-			if (maxProp && maxProp.key){
-				return maxProp.key;
-			}
-		}
-
-		var rgbToHex = function (rgbStr){
-
-			var rgbParts = rgbStr.split('(')[1].split(',').map(function(rgbPart){
-				return parseInt(rgbPart,10);
-			});
-
-
-			function componentToHex(c) {
-				var hex = c.toString(16);
-				return hex.length == 1 ? "0" + hex : hex;
-			}
-
-			return "#" + componentToHex(rgbParts[0]) + componentToHex(rgbParts[1]) + componentToHex(rgbParts[2]);
-
-		}
-
-		if (selectedNodes.length == 1){
-			var unique = getUniqueFontStyles(selectedNodes[0]);
-			return {
-				textVisibleCharCount: getVisibleCharCount(selectedNodes[0]),
-				textUniqueFontStyleCount: _count(unique.fontStyles),
-				textUniqueFontStyles: unique.fontStyles,
-				textUniqueFontSizeCount: _count(unique.fontStyles),
-				textUniqueFontSizes: unique.fontSizes,
-				textUniqueFontCount: _count(unique.fonts),
-				textUniqueFonts: unique.fonts,
-				textTopFont: getMaxProperty((unique.fonts)),
-				textTopFontStyle:getMaxProperty(unique.fontStyles),
-				textTopFontColor:getMaxProperty(unique.fontColors),
-				textTopFontSize: getMaxProperty(unique.fontSizes),
-				textUniqueFontColorCount: _count(unique.fontColors),
-				textUniqueFontColors: unique.fontColors,
-				textFirst1000Chars: _toText(_getVisibleTextNodes(selectedNodes[0])).slice(0,1000),
-				version: '0.0.1'
-			};
-		}
-
-		return selectedNodes.forEach(function(node){
-			return getVisibleCharCount(node);
-		});
 	}
+
+	LayoutStats.addMetric = function (metricObj){
+		if (!this.metrics){
+			this.metrics = [];
+		}
+		this.metrics.push(metricObj);
+	}
+
+	window.layoutstats = function(node, options){
+		return (new LayoutStats()).measure(node, options);
+	}
+
+
+function incrementAcc (acc, item){
+	if (item && item.key && item.value){
+		acc[item.key] = (acc[item.key]||0) + item.value;
+	}
+	return acc;
+}
+
+var reducers = {
+	'sum': {
+		fn: function (acc, item){
+			return acc + item;
+		},
+		initialValue: 0
+	},
+	'unique': {
+		fn: function (acc, item){
+			acc = incrementAcc(acc, item);
+			return acc;
+		},
+		initialValue: {},
+		metricPrefix: 'Unique',
+		metricSuffix: 's'
+	},
+	'uniquecount': {
+		fn: function (acc, item, itemIndex, array){
+			acc = incrementAcc(acc, item);
+
+			//return the total count if we arrived at the last element
+			if (itemIndex === array.length -1){
+				return Object.keys(acc).length;
+			}
+			return acc;
+		},
+		initialValue: {},
+		metricPrefix: 'Unique',
+		metricSuffix: 'Count'
+	},
+	'top': {
+		fn: function (acc, item, itemIndex, array){
+			acc = incrementAcc(acc, item);
+			//return the total count if we arrived at the last element
+			if (itemIndex === array.length -1){
+				var descendingOrder = Object.keys(acc).sort(function(keyA, keyB){
+					return acc[keyB] -acc[keyA]
+				});
+				return descendingOrder[0];
+			}
+			return acc;
+		},
+		initialValue: {},
+		metricPrefix: "Top"
+	}
+
+
+
+}
+
+var rgbToHex = function (rgbStr){
+
+	var rgbParts = rgbStr.split('(')[1].split(',').map(function(rgbPart){
+		return parseInt(rgbPart,10);
+	});
+
+
+	function componentToHex(c) {
+		var hex = c.toString(16);
+		return hex.length == 1 ? "0" + hex : hex;
+	}
+
+	return "#" + componentToHex(rgbParts[0]) + componentToHex(rgbParts[1]) + componentToHex(rgbParts[2]);
+
+}
+
+LayoutStats.addMetric({
+	group: "text",
+	name: "VisibleCharCount",
+	value: function (node){
+		return node.textContent.length
+	},
+	reduce: 'sum'
+});
+
+LayoutStats.addMetric({
+	group: "text",
+	name: "Font",
+	value: function (node){
+		var fontFamilies = getComputedStyle(node.parentNode).fontFamily;
+		var firstFont = fontFamilies.split(",")[0];
+		return {key: firstFont.toLowerCase(), value: node.textContent.length};
+	},
+	reduce: ['unique','uniquecount','top']
+});
+
+LayoutStats.addMetric({
+	group: "text",
+	name: "FontStyle",
+	value: function (node){
+		var css = getComputedStyle(node.parentNode); //$textParent.css(['fontFamily','fontSize','fontWeight','fontVariant','fontStyle','color']);
+		var styleParams = JSON.parse(JSON.stringify(css));
+		styleParams.fontSize = Math.round(parseInt(styleParams.fontSize, 10)) + 'px';
+		styleParams.color = rgbToHex(styleParams.color);
+
+
+		var miscProperties = '';
+		miscProperties += (styleParams.fontWeight === "bold" || parseInt(styleParams.fontWeight, 10) > 699 ? "bold": ""); //bold font?
+		miscProperties += (styleParams.fontStyle !== "normal" ? " " +styleParams.fontStyle: ""); //italics font?
+		miscProperties += (styleParams.fontVariant !== "normal" ? " " + styleParams.fontVariant: ""); //small caps?
+
+		var nodeStyle = [
+			styleParams.fontFamily.split(",")[0].toLowerCase(),
+			styleParams.fontSize,
+			styleParams.color,
+		];
+
+		if (miscProperties.length > 0){
+			nodeStyle.push(miscProperties);
+		}
+
+		return {key: nodeStyle.join(' '), value: node.textContent.length};
+	},
+	reduce: ['unique','uniquecount','top']
+});
+
+LayoutStats.addMetric({
+	group: "text",
+	name: "FontSize",
+	value: function (node){
+		var fontSize = getComputedStyle(node.parentNode).fontSize;
+		 fontSize = Math.round(parseInt(fontSize, 10)) + 'px';
+		return {key: fontSize, value: node.textContent.length};
+	},
+	reduce: ['unique','uniquecount','top']
+});
+
+LayoutStats.addMetric({
+	group: "text",
+	name: "FontColor",
+	value: function (node){
+		var color = getComputedStyle(node.parentNode).color;
+		var hexColor =  rgbToHex(color);
+		return {key: hexColor, value: node.textContent.length}
+	},
+	reduce: ['unique','uniquecount','top']
+});
+
+LayoutStats.addMetric({
+	group: "text",
+	name: "First1000Chars",
+	value: function (node){
+		return node.textContent;
+	},
+	reduce: {
+		fn: function (acc, item){
+			return (acc + item).slice(0,1000);
+		},
+		initialValue: ''
+	}
+});
+
 
 
 } )( window, document );

--- a/src/layoutstats.js
+++ b/src/layoutstats.js
@@ -139,6 +139,23 @@ var reducers = {
 		},
 		initialValue: {},
 		metricPrefix: "Top"
+	},
+	'average': {
+		fn: function (acc, item, itemIndex, array){
+			acc = incrementAcc(acc, item);
+			//return the total count if we arrived at the last element
+			if (itemIndex === array.length -1){
+				var avg = Object.keys(acc).reduce(function(avg,key){
+					avg.sum += (parseInt(key,10) * acc[key]);
+					avg.amount += acc[key]
+					return avg
+				},{sum: 0,amount:0});
+				return avg.sum/avg.amount;
+			}
+			return acc;
+		},
+		initialValue: {},
+		metricPrefix: "Average"
 	}
 }
 
@@ -216,7 +233,7 @@ LayoutStats.addMetric({
 		 fontSize = Math.round(parseInt(fontSize, 10)) + 'px';
 		return {key: fontSize, value: node.textContent.length};
 	},
-	reduce: ['unique','uniquecount','top']
+	reduce: ['unique','uniquecount','top','average']
 });
 
 LayoutStats.addMetric({

--- a/test/spec/jquery.layoutstats.textmetrics.spec.js
+++ b/test/spec/jquery.layoutstats.textmetrics.spec.js
@@ -68,12 +68,12 @@
 		var topPropertyTests = [
 			{
 				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;">1234</div>',
-				expected: {topFont: "arial", topStyle: "arial 11px #000000", topSize: "11px", topColor: "#000000"},
+				expected: {topFont: "arial", topStyle: "arial 11px #000000", fontList: ["arial"], topSize: "11px", topColor: "#000000"},
 				assertion: 'returns the top font size/style/color/variant used in an html document'
 			},
 			{
 				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;"><small style="font-family: serif;">1</small><b>234</b></div>',
-				expected: {topFont: "arial", topStyle: "arial 11px #000000 bold", topSize: "11px", topColor: "#000000"},
+				expected: {topFont: "arial", topStyle: "arial 11px #000000 bold", fontList: ["arial","serif"],topSize: "11px", topColor: "#000000"},
 				assertion: 'uses inherited styles for its calculations'
 			},
 		];
@@ -85,6 +85,7 @@
 			var res = layoutstats(charDiv);
 			var result = {
 				topFont: res.textTopFont,
+				fontList: res.textFontList,
 				topStyle: res.textTopFontStyle,
 				topSize: res.textTopFontSize,
 				topColor: res.textTopFontColor

--- a/test/spec/jquery.layoutstats.textmetrics.spec.js
+++ b/test/spec/jquery.layoutstats.textmetrics.spec.js
@@ -68,12 +68,12 @@
 		var topPropertyTests = [
 			{
 				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;">1234</div>',
-				expected: {topFont: "Arial", topStyle: "Arial 11px #000000", topSize: "11px", topColor: "#000000"},
+				expected: {topFont: "arial", topStyle: "arial 11px #000000", topSize: "11px", topColor: "#000000"},
 				assertion: 'returns the top font size/style/color/variant used in an html document'
 			},
 			{
 				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;"><small style="font-family: serif;">1</small><b>234</b></div>',
-				expected: {topFont: "Arial", topStyle: "Arial 11px #000000 bold", topSize: "11px", topColor: "#000000"},
+				expected: {topFont: "arial", topStyle: "arial 11px #000000 bold", topSize: "11px", topColor: "#000000"},
 				assertion: 'uses inherited styles for its calculations'
 			},
 		];

--- a/test/spec/jquery.layoutstats.textmetrics.spec.js
+++ b/test/spec/jquery.layoutstats.textmetrics.spec.js
@@ -64,16 +64,16 @@
 
 	});
 
-	QUnit.test( "find the top font and font style/color/size", function( assert ) {
+	QUnit.test( "finds the top font and font style/color/size, the list of fonts and the average font size", function( assert ) {
 		var topPropertyTests = [
 			{
 				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;">1234</div>',
-				expected: {topFont: "arial", topStyle: "arial 11px #000000", fontList: ["arial"], topSize: "11px", topColor: "#000000"},
-				assertion: 'returns the top font size/style/color/variant used in an html document'
+				expected: {topFont: "arial", topStyle: "arial 11px #000000", fontList: ["arial"], topSize: "11px", avgFontSize: 11, topColor: "#000000"},
+				assertion: 'returns the top font size/style/color/variant as well as the list of fonts and the average font size used in an html document'
 			},
 			{
-				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;"><small style="font-family: serif;">1</small><b>234</b></div>',
-				expected: {topFont: "arial", topStyle: "arial 11px #000000 bold", fontList: ["arial","serif"],topSize: "11px", topColor: "#000000"},
+				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;"><small style="font-family: serif; font-size: 7px;">1</small><b>234</b></div>',
+				expected: {topFont: "arial", topStyle: "arial 11px #000000 bold", fontList: ["arial","serif"],topSize: "11px", avgFontSize: 10, topColor: "#000000"},
 				assertion: 'uses inherited styles for its calculations'
 			},
 		];
@@ -86,6 +86,7 @@
 			var result = {
 				topFont: res.textTopFont,
 				fontList: res.textFontList,
+				avgFontSize: res.textAverageFontSize,
 				topStyle: res.textTopFontStyle,
 				topSize: res.textTopFontSize,
 				topColor: res.textTopFontColor

--- a/test/spec/jquery.layoutstats.textmetrics.spec.js
+++ b/test/spec/jquery.layoutstats.textmetrics.spec.js
@@ -68,12 +68,12 @@
 		var topPropertyTests = [
 			{
 				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;">1234</div>',
-				expected: {topFont: "arial", topStyle: "arial 11px #000000", fontList: ["arial"], topSize: "11px", avgFontSize: 11, topColor: "#000000"},
-				assertion: 'returns the top font size/style/color/variant as well as the list of fonts and the average font size used in an html document'
+				expected: {topFont: "arial", topStyle: "arial 11px #000000", fontList: ["arial"], topSize: "11px", avgFontSize: 11, topColor: "#000000", avgRelativeLineHeight: 1},
+				assertion: 'returns the top font size/style/color/variant as well as the list of fonts and the average font size/line height used in an html document'
 			},
 			{
-				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;"><small style="font-family: serif; font-size: 7px;">1</small><b>234</b></div>',
-				expected: {topFont: "arial", topStyle: "arial 11px #000000 bold", fontList: ["arial","serif"],topSize: "11px", avgFontSize: 10, topColor: "#000000"},
+				node: '<div style="font-family: Arial, sans-serif; font-size: 11px;"><small style="font-family: serif; font-size: 7px;line-height:21px;">1</small><b>234</b></div>',
+				expected: {topFont: "arial", topStyle: "arial 11px #000000 bold", fontList: ["arial","serif"],topSize: "11px", avgFontSize: 10, avgRelativeLineHeight: 1.5, topColor: "#000000"},
 				assertion: 'uses inherited styles for its calculations'
 			},
 		];
@@ -87,6 +87,7 @@
 				topFont: res.textTopFont,
 				fontList: res.textFontList,
 				avgFontSize: res.textAverageFontSize,
+				avgRelativeLineHeight: res.textAverageRelativeLineHeight,
 				topStyle: res.textTopFontStyle,
 				topSize: res.textTopFontSize,
 				topColor: res.textTopFontColor


### PR DESCRIPTION
with this PR, we introduce a plugin architecture to layoutstats: layout metrics are no longer calculated in a monolithic routine. Instead, each metric can be developed as a plugin that registers itself to the main layoutstats application. The calculation of the metric happens in a map/reduce fashion - please check the included metrics for an example. Note: this is our first step towards a plugin-based architecture - please don't consider the API as stable, since we want to introduce further features (e.g. toggle a metric on/off, configuration parameters per metric, improved map/reduce).